### PR TITLE
Add Snaplert to Hosted Services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ Closed source unless indicated otherwise.
 - [OnWebChange][]
 - [PageFreezer][]
 - [PageCrawl][]
+- [Snaplert][]. Visual page change monitoring with before/after screenshots, element/zone selection, and email/webhook alerts.
 - [TheWebWatcher][] :beer:
 - [Trackly][]
 - [Versionista][]
@@ -113,4 +114,5 @@ related or neighboring rights to this work.
    [timemachine-code]: https://bitbucket.org/metamorfozis/news
    [website-change-monitor]: https://github.com/JuanmaMenendez/website-change-monitor
    [changedetection.io]: https://changedetection.io/
+   [snaplert]: https://snaplert.com/
 


### PR DESCRIPTION
Adds [Snaplert](https://snaplert.com/) to the Hosted Services list under Content Diffing.

Snaplert is a hosted website change monitoring service: it takes periodic screenshots of any public webpage, compares them, and alerts you (email/webhook) when something changes. It supports element/zone selection and before/after visual diffs.

Entry placed alphabetically and uses the existing reference-link style.